### PR TITLE
Change tag name

### DIFF
--- a/FME/CityGML_UtilityNetworkADE_feature_types.xml
+++ b/FME/CityGML_UtilityNetworkADE_feature_types.xml
@@ -60,7 +60,7 @@
   <utility:Cable/>
   <utility:Canal/>
   <utility:ClosedCanal/>
-  <utility:ComplexFunctionalElement/>
+  <utility:ComplexFunctionalComponent/>
   <utility:CompositeSwitch/>
   <utility:Conductor/>
   <utility:ConnectionComponent/>


### PR DESCRIPTION
The tag name in the reference .xsd is ComplexFunctionalComponent, not "Element".